### PR TITLE
feat: add generator script skeleton

### DIFF
--- a/scripts/generate_mapping.py
+++ b/scripts/generate_mapping.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Generate a markdown mapping document from an OSCAL Component Definition JSON file.
+
+Reads the nested OSCAL structure:
+  component-definition → components[] → control-implementations[] → implemented-requirements[]
+
+and produces a markdown table mapping NIST 800-53 Rev 5 controls to AWS services.
+"""
+
+import argparse
+import json
+import sys
+
+
+def parse_args():
+    """Parse command-line arguments for input and output paths.
+
+    Uses argparse following the same CLI pattern as compliance-trestle:
+    explicit --input and --output flags, no positional arguments, no hardcoded paths.
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate a NIST 800-53 Rev 5 to AWS mapping from OSCAL Component Definition JSON."
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to the OSCAL Component Definition JSON file.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path for the generated markdown file.",
+    )
+    return parser.parse_args()
+
+
+def load_component_definition(input_path):
+    """Load and return the OSCAL Component Definition from a JSON file.
+
+    Handles two expected failure modes separately so the error message
+    tells you *what* went wrong (PCC3e Ch 10 — using specific exception
+    types rather than a bare except).
+
+    Returns the top-level component-definition dict on success.
+    Prints an error message and exits with code 1 on failure.
+    """
+    try:
+        with open(input_path, "r") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        print(f"Error: Input file not found: {input_path}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON in {input_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    return data
+
+
+def extract_mappings(component_definition):
+    """Walk the OSCAL Component Definition and extract control-to-service mappings.
+
+    Traverses three levels of nesting:
+      1. components[] — each AWS service
+      2. control-implementations[] — per-framework grouping (e.g., NIST 800-53 source)
+      3. implemented-requirements[] — per-control detail
+
+    For each implemented-requirement, extracts the control-id, description,
+    and custom props (fedramp-high, cjis-delta).
+
+    Returns a list of dicts, each representing one row in the output table.
+    """
+    mappings = []
+
+    # Access the components array from the top-level component-definition object.
+    # .get() returns an empty list if the key is missing, so the for loop
+    # simply doesn't execute rather than raising a KeyError (PCC3e Ch 6 — dict.get()).
+    components = component_definition.get("component-definition", {}).get("components", [])
+
+    for component in components:
+        service_title = component.get("title", "Unknown Service")
+
+        # Second level: control-implementations[] — the per-framework grouping.
+        control_implementations = component.get("control-implementations", [])
+
+        for ctrl_impl in control_implementations:
+            # Third level: implemented-requirements[] — the per-control detail.
+            implemented_reqs = ctrl_impl.get("implemented-requirements", [])
+
+            for req in implemented_reqs:
+                control_id = req.get("control-id", "unknown")
+                description = req.get("description", "")
+
+                # Extract props into a dict keyed by prop name for easy lookup.
+                # Props is a list of {"name": ..., "value": ...} objects.
+                props = {p["name"]: p["value"] for p in req.get("props", [])}
+
+                fedramp_high = props.get("fedramp-high", "false")
+                cjis_delta = props.get("cjis-delta", "")
+
+                mappings.append({
+                    "control_id": control_id.upper(),
+                    "service": service_title,
+                    "description": description,
+                    "fedramp_high": fedramp_high,
+                    "cjis_delta": cjis_delta,
+                })
+
+    return mappings
+
+
+def write_markdown(mappings, output_path):
+    """Write the extracted mappings to a markdown file as a table.
+
+    Uses a with statement for safe file handling — the file is closed
+    automatically even if an error occurs during writing (PCC3e Ch 10).
+    """
+    try:
+        with open(output_path, "w") as f:
+            f.write("# NIST 800-53 Rev 5 to AWS Service Mapping\n\n")
+            f.write("| Control ID | AWS Service | Description | FedRAMP High | CJIS Delta |\n")
+            f.write("|------------|-------------|-------------|:------------:|------------|\n")
+
+            for mapping in mappings:
+                # Replace pipe characters in description text so they don't
+                # break the markdown table structure.
+                desc = mapping["description"].replace("|", "\\|")
+                cjis = mapping["cjis_delta"].replace("|", "\\|")
+
+                f.write(
+                    f"| {mapping['control_id']} "
+                    f"| {mapping['service']} "
+                    f"| {desc} "
+                    f"| {mapping['fedramp_high']} "
+                    f"| {cjis if cjis else 'N/A'} "
+                    f"|\n"
+                )
+    except OSError as e:
+        print(f"Error: Could not write to {output_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Generated mapping: {output_path}")
+
+
+def main():
+    args = parse_args()
+    data = load_component_definition(args.input)
+    mappings = extract_mappings(data)
+    write_markdown(mappings, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `scripts/generate_mapping.py` that reads OSCAL Component Definition JSON and generates a markdown mapping table
- CLI uses `argparse` with `--input` and `--output` flags (no hardcoded paths)
- Error handling for missing files and invalid JSON (exits with code 1 and actionable message)
- Traverses full OSCAL nesting: components → control-implementations → implemented-requirements

## Test Plan
- [x] `python scripts/generate_mapping.py --input data/component-definition.json --output output/nist-aws-mapping.md` produces valid markdown
- [x] Missing input file prints error to stderr and exits 1
- [x] Invalid JSON prints decode error to stderr and exits 1
- [x] No hardcoded paths — all paths via argparse

Closes #3