### PR TITLE
docs: add README badges for portfolio visual coherence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+![License](https://img.shields.io/badge/License-MIT-green?style=flat)
+![AWS](https://img.shields.io/badge/AWS-Service%20Mapping-FF9900?style=flat&logo=amazonwebservices)
+![OSCAL](https://img.shields.io/badge/OSCAL-Component%20Definition-1c5b94?style=flat)
+![NIST 800-53](https://img.shields.io/badge/NIST-800--53%20Rev%205-004990?style=flat)
+![FedRAMP](https://img.shields.io/badge/FedRAMP-High%20Baseline-0071bc?style=flat)
+![CJIS](https://img.shields.io/badge/CJIS-Security%20Policy%20v6.0-cc0000?style=flat)
+
 # NIST 800-53 Rev 5 to AWS Service Mapping
 
 Maps NIST 800-53 Rev 5 security controls to AWS services that support their implementation, stored as an OSCAL Component Definition JSON file. A Python generator script renders the mapping as markdown with FedRAMP High baseline filtering and a CJIS v6.0 delta section highlighting where CJIS exceeds FedRAMP requirements. Built for GRC engineers, compliance analysts, and assessors working in FedRAMP High and CJIS v6.0 environments.


### PR DESCRIPTION
## Summary
- Adds the standardized 6-badge block to the top of `README.md` (License, AWS Service Mapping, OSCAL Component Definition, NIST 800-53 Rev 5, FedRAMP High Baseline, CJIS Security Policy v6.0)
- Matches the portfolio house style used in `aws-compliance-as-code`, `aws-config-compliance-monitor`, and `aws-grc-terraform-modules`
- Python badge intentionally omitted — this is fundamentally a control-mapping dataset (OSCAL Component Definition JSON + emitted markdown), not a Python tool; the generator script is incidental to the deliverable
- No body content changed below the badge block

## Test Plan
- [ ] Open the README on GitHub after merge and confirm all six badges render in order
- [ ] Confirm the H1 and Compliance Controls Addressed table still appear unchanged below the badges

Closes #22