### PR TITLE
docs: correct CJIS v6.0 audit timeline to phased rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The OSCAL Component Definition format aligns with FedRAMP 20x compliance-as-code
 
 ## CJIS v6.0 Relevance
 
-CJIS v6.0 aligns with NIST 800-53 Rev 5 as of December 2024 and becomes the audit standard on April 1, 2026. This mapping identifies 5 controls where CJIS exceeds FedRAMP High: quarterly account reviews (AC-2), phishing-resistant AAL2 MFA (IA-2), 1-year audit log retention with weekly review (AU-6), agency-managed encryption keys (SC-28), and incident reporting to the CSO/FBI CJIS Division (IR-6).
+CJIS v6.0 (published Dec 27, 2024) aligns to NIST 800-53 Rev 5 and phases in rather than switching on a single date: v5.9.5 was the scored audit standard through March 31, 2026 and v6.0 is the default audit baseline from April 1, 2026, with modernized Priority 2-4 controls fully enforceable Oct 1, 2027 (timing varies by state CSA). This mapping identifies 5 controls where CJIS exceeds FedRAMP High: quarterly account reviews (AC-2), phishing-resistant AAL2 MFA (IA-2), 1-year audit log retention with weekly review (AU-6), agency-managed encryption keys (SC-28), and incident reporting to the CSO/FBI CJIS Division (IR-6).
 
 ## Sample Evidence Output
 


### PR DESCRIPTION
## Summary
- Corrects the CJIS v6.0 audit-timeline language from a single-cutover framing ("v6.0 becomes/became the audit standard on April 1, 2026") to the verified phased rollout.
- Phased framing: v5.9.5 was the scored audit standard through March 31, 2026; v6.0 is the default audit baseline from April 1, 2026; modernized Priority 2–4 controls fully enforceable Oct 1, 2027 (timing varies by state CSA).
- Surrounding control content (AU-6 / SC-28 / delta mappings) preserved verbatim.

## Why
The April 1, 2026 date is the default go-forward audit baseline, not a one-day enforcement cutover. The corrected framing matches the FBI CJIS v6.0 phased rollout.

## Test Plan
- [x] Dates cross-checked against the canonical reconciled CJIS v6.0 timeline
- [x] Grep sweep — zero residual single-cutover phrasing in tracked files

Factual documentation correction — no issue.